### PR TITLE
ci: add dev branch trigger to APK build workflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -2,7 +2,7 @@ name: Build Android APK
 
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
     paths:
       - 'src/**'
       - 'APK/**'
@@ -10,7 +10,7 @@ on:
       - 'vite.config.ts'
       - '.github/workflows/build-apk.yml'
   pull_request:
-    branches: [master]
+    branches: [master, dev]
   workflow_call:
     inputs:
       release_tag:


### PR DESCRIPTION
The build-apk workflow now also triggers on pushes and PRs to the dev
branch, enabling APK testing before merging to master.

https://claude.ai/code/session_011To9kcKZkjigtu28cgqw8u