### PR TITLE
feat: add background auto-booking with Android notifications

### DIFF
--- a/APK/android/app/src/main/res/drawable/ic_stat_directions_car.xml
+++ b/APK/android/app/src/main/res/drawable/ic_stat_directions_car.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Simple car icon for notification small icon (24dp) -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M18.92,6.01C18.72,5.42 18.16,5 17.5,5h-11c-0.66,0 -1.21,0.42 -1.42,1.01L3,12v8c0,0.55 0.45,1 1,1h1c0.55,0 1,-0.45 1,-1v-1h12v1c0,0.55 0.45,1 1,1h1c0.55,0 1,-0.45 1,-1v-8l-2.08,-5.99zM6.5,16C5.67,16 5,15.33 5,14.5S5.67,13 6.5,13 8,13.67 8,14.5 7.33,16 6.5,16zM17.5,16c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5zM5,11l1.5,-4.5h11L19,11L5,11z"/>
+</vector>

--- a/APK/package-lock.json
+++ b/APK/package-lock.json
@@ -10,6 +10,7 @@
         "@capacitor/browser": "^8.0.0",
         "@capacitor/cli": "^8.3.0",
         "@capacitor/core": "^8.3.0",
+        "@capacitor/local-notifications": "^8.0.1",
         "@capacitor/preferences": "^8.0.0"
       }
     },
@@ -84,6 +85,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/local-notifications": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.0.2.tgz",
+      "integrity": "sha512-X7KE/I4ZutMTGVHNUyTjIugYcQEcHJRLks+TsPnOriuS+lo0geSTuaRln6zAZlJSSXSoVMSSzHexdSbIjR/8iw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/preferences": {

--- a/APK/package.json
+++ b/APK/package.json
@@ -10,6 +10,7 @@
     "@capacitor/android": "^8.3.0",
     "@capacitor/cli": "^8.3.0",
     "@capacitor/core": "^8.3.0",
+    "@capacitor/local-notifications": "^8.0.1",
     "@capacitor/preferences": "^8.0.0",
     "@capacitor/browser": "^8.0.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/app": "^8.0.1",
         "@capacitor/browser": "^8.0.2",
         "@capacitor/core": "^8.2.0",
+        "@capacitor/local-notifications": "^8.0.1",
         "@capacitor/preferences": "^8.0.1",
         "@popperjs/core": "^2.11.8",
         "axios": "^1.7.0",
@@ -102,6 +103,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/local-notifications": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.0.2.tgz",
+      "integrity": "sha512-X7KE/I4ZutMTGVHNUyTjIugYcQEcHJRLks+TsPnOriuS+lo0geSTuaRln6zAZlJSSXSoVMSSzHexdSbIjR/8iw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/preferences": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@capacitor/app": "^8.0.1",
     "@capacitor/browser": "^8.0.2",
     "@capacitor/core": "^8.2.0",
+    "@capacitor/local-notifications": "^8.0.1",
     "@capacitor/preferences": "^8.0.1",
     "@popperjs/core": "^2.11.8",
     "axios": "^1.7.0",

--- a/src/composables/useBackgroundAutoBook.ts
+++ b/src/composables/useBackgroundAutoBook.ts
@@ -1,0 +1,178 @@
+import { ref, computed } from 'vue';
+import { Capacitor } from '@capacitor/core';
+import { getAvailableVehicles, createBooking } from '@/services/communautoDataService';
+import { haversineDistance, type LatLng } from '@/composables/useGeolocation';
+import { useAuth } from '@/composables/useAuth';
+import {
+  requestNotificationPermission,
+  showScanningNotification,
+  updateScanningNotification,
+  clearScanningNotification,
+  showBookedNotification,
+  showErrorNotification,
+} from '@/services/notificationService';
+import type { VehicleV3 } from '@/types/Vehicule';
+
+const isNative = Capacitor.isNativePlatform();
+
+// Singleton state — shared across components
+const active = ref(false);
+const error = ref<string | null>(null);
+const success = ref<string | null>(null);
+const scanCount = ref(0);
+
+let scanTimer: ReturnType<typeof setInterval> | null = null;
+let inProgress = false;
+
+/**
+ * Background-capable auto-booking composable.
+ *
+ * On Android (APK), this shows a persistent notification while scanning
+ * and a success notification when a car is booked. The scan continues
+ * even when the app is in the background (WebView timers are throttled
+ * but still fire on Android).
+ */
+export function useBackgroundAutoBook() {
+  const { wcfCookies } = useAuth();
+
+  function getUidFromCookies(): number | null {
+    const match = wcfCookies.value?.match(/uid=(\d+)/);
+    return match ? parseInt(match[1]) : null;
+  }
+
+  async function start(userLocation: LatLng, radius: number, intervalSeconds: number, electricFilter: 'all' | 'electric' | 'gas') {
+    if (active.value) return;
+
+    error.value = null;
+    success.value = null;
+    scanCount.value = 0;
+    active.value = true;
+
+    // Request notification permission on native
+    if (isNative) {
+      await requestNotificationPermission();
+      await showScanningNotification(radius);
+    }
+
+    // Run immediately, then on interval
+    await scan(userLocation, radius, electricFilter);
+
+    scanTimer = setInterval(() => {
+      scan(userLocation, radius, electricFilter);
+    }, intervalSeconds * 1000);
+  }
+
+  async function stop() {
+    active.value = false;
+    if (scanTimer) {
+      clearInterval(scanTimer);
+      scanTimer = null;
+    }
+    await clearScanningNotification();
+  }
+
+  async function scan(userLocation: LatLng, radius: number, electricFilter: 'all' | 'electric' | 'gas') {
+    if (!active.value || inProgress) return;
+    inProgress = true;
+
+    try {
+      scanCount.value++;
+
+      // Fetch vehicles
+      const response = await getAvailableVehicles();
+      const vehicles: VehicleV3[] = response.data.d.Vehicles;
+
+      // Calculate distances and filter
+      const candidates = vehicles
+        .map((v) => ({
+          ...v,
+          distance: haversineDistance(userLocation, { lat: v.Latitude, lng: v.Longitude }),
+        }))
+        .filter((v) => v.distance <= radius)
+        .filter((v) =>
+          electricFilter === 'all' ||
+          (electricFilter === 'electric' ? v.IsElectric : !v.IsElectric),
+        )
+        .sort((a, b) => a.distance - b.distance);
+
+      if (isNative && active.value) {
+        await updateScanningNotification(
+          `Scan #${scanCount.value} — ${candidates.length} véhicule(s) dans ${radius} m`,
+        );
+      }
+
+      if (candidates.length === 0) {
+        // No cars found, will retry on next interval
+        return;
+      }
+
+      // Try to book
+      const uid = getUidFromCookies();
+      if (!uid) {
+        error.value = 'uid introuvable dans les cookies';
+        await stop();
+        if (isNative) await showErrorNotification(error.value);
+        return;
+      }
+
+      for (const car of candidates) {
+        try {
+          const res = await createBooking(uid, car.CarId);
+          const data = res.data?.d ?? res.data;
+
+          if (data?.Success) {
+            success.value = `Réservé: #${car.CarNo} — ${car.CarBrand} ${car.CarModel} (${Math.round(car.distance)} m)`;
+            active.value = false;
+            if (scanTimer) {
+              clearInterval(scanTimer);
+              scanTimer = null;
+            }
+            if (isNative) {
+              await showBookedNotification(car.CarNo, car.CarBrand, car.CarModel, car.distance);
+            }
+            return;
+          }
+
+          // Booking limit on this car — try next
+          if (data?.ErrorType === 3) {
+            error.value = `#${car.CarNo} limite atteinte, essai suivant...`;
+            continue;
+          }
+
+          // Other error — stop
+          const errMsg = data?.ErrorMessage || 'Réservation échouée';
+          error.value = errMsg;
+          await stop();
+          if (isNative) await showErrorNotification(errMsg);
+          return;
+        } catch (e: unknown) {
+          const errMsg = e instanceof Error ? e.message : 'Erreur réseau';
+          error.value = errMsg;
+          await stop();
+          if (isNative) await showErrorNotification(errMsg);
+          return;
+        }
+      }
+
+      // All cars had booking limit reached
+      error.value = 'Limite atteinte sur tous les véhicules dans le rayon';
+    } catch (e: unknown) {
+      // Network error during fetch — keep scanning, don't stop
+      error.value = e instanceof Error ? e.message : 'Erreur réseau lors du scan';
+      if (isNative && active.value) {
+        await updateScanningNotification(`Erreur réseau — nouvelle tentative...`);
+      }
+    } finally {
+      inProgress = false;
+    }
+  }
+
+  return {
+    active: computed(() => active.value),
+    error: computed(() => error.value),
+    success: computed(() => success.value),
+    scanCount: computed(() => scanCount.value),
+    start,
+    stop,
+  };
+}

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,93 @@
+import { Capacitor } from '@capacitor/core';
+import { LocalNotifications } from '@capacitor/local-notifications';
+
+const isNative = Capacitor.isNativePlatform();
+
+// Fixed notification IDs
+const SCANNING_NOTIFICATION_ID = 9001;
+const BOOKED_NOTIFICATION_ID = 9002;
+
+/** Request notification permissions (call once at startup or before first use) */
+export async function requestNotificationPermission(): Promise<boolean> {
+  if (!isNative) return false;
+  const perm = await LocalNotifications.requestPermissions();
+  return perm.display === 'granted';
+}
+
+/** Show an ongoing notification while scanning for vehicles */
+export async function showScanningNotification(radius: number) {
+  if (!isNative) return;
+  await LocalNotifications.schedule({
+    notifications: [
+      {
+        id: SCANNING_NOTIFICATION_ID,
+        title: 'Recherche en cours...',
+        body: `Scan automatique dans un rayon de ${radius} m`,
+        ongoing: true,
+        autoCancel: false,
+        smallIcon: 'ic_stat_directions_car',
+        largeIcon: 'ic_launcher',
+      },
+    ],
+  });
+}
+
+/** Update the scanning notification with current status */
+export async function updateScanningNotification(body: string) {
+  if (!isNative) return;
+  await LocalNotifications.schedule({
+    notifications: [
+      {
+        id: SCANNING_NOTIFICATION_ID,
+        title: 'Recherche en cours...',
+        body,
+        ongoing: true,
+        autoCancel: false,
+        smallIcon: 'ic_stat_directions_car',
+        largeIcon: 'ic_launcher',
+      },
+    ],
+  });
+}
+
+/** Remove the scanning notification */
+export async function clearScanningNotification() {
+  if (!isNative) return;
+  await LocalNotifications.cancel({ notifications: [{ id: SCANNING_NOTIFICATION_ID }] });
+}
+
+/** Show a notification when a car has been booked */
+export async function showBookedNotification(carNo: number | string, carBrand: string, carModel: string, distance: number) {
+  if (!isNative) return;
+  // Clear the scanning notification first
+  await clearScanningNotification();
+  await LocalNotifications.schedule({
+    notifications: [
+      {
+        id: BOOKED_NOTIFICATION_ID,
+        title: 'Véhicule réservé!',
+        body: `#${carNo} — ${carBrand} ${carModel} (${Math.round(distance)} m)`,
+        smallIcon: 'ic_stat_directions_car',
+        largeIcon: 'ic_launcher',
+        sound: 'default',
+      },
+    ],
+  });
+}
+
+/** Show an error notification */
+export async function showErrorNotification(message: string) {
+  if (!isNative) return;
+  await clearScanningNotification();
+  await LocalNotifications.schedule({
+    notifications: [
+      {
+        id: BOOKED_NOTIFICATION_ID,
+        title: 'Auto-réservation arrêtée',
+        body: message,
+        smallIcon: 'ic_stat_directions_car',
+        largeIcon: 'ic_launcher',
+      },
+    ],
+  });
+}

--- a/src/views/Radar.vue
+++ b/src/views/Radar.vue
@@ -71,24 +71,24 @@
         <!-- Auto-book -->
         <div v-if="isAuthenticated" class="mb-3">
           <button
-            v-if="!autoBookActive"
+            v-if="!bgAutoBook.active.value"
             class="btn btn-warning btn-sm w-100"
-            @click="startAutoBook"
+            @click="handleStartAutoBook"
           >
             Auto-réserver ({{ radius }} m)
           </button>
           <button
             v-else
             class="btn btn-danger btn-sm w-100"
-            @click="stopAutoBook"
+            @click="bgAutoBook.stop()"
           >
             Arrêter auto-réservation
           </button>
-          <div v-if="autoBookActive" class="text-muted small mt-1">
-            En attente d'un véhicule dans {{ radius }} m...
+          <div v-if="bgAutoBook.active.value" class="text-muted small mt-1">
+            Scan #{{ bgAutoBook.scanCount.value }} — en attente d'un véhicule dans {{ radius }} m...
           </div>
-          <div v-if="autoBookError" class="alert alert-danger alert-sm mt-1 mb-0 py-1 px-2 small">{{ autoBookError }}</div>
-          <div v-if="autoBookSuccess" class="alert alert-success alert-sm mt-1 mb-0 py-1 px-2 small">{{ autoBookSuccess }}</div>
+          <div v-if="bgAutoBook.error.value" class="alert alert-danger alert-sm mt-1 mb-0 py-1 px-2 small">{{ bgAutoBook.error.value }}</div>
+          <div v-if="bgAutoBook.success.value" class="alert alert-success alert-sm mt-1 mb-0 py-1 px-2 small">{{ bgAutoBook.success.value }}</div>
         </div>
 
         <div class="list-group list-group-flush" style="max-height: 60vh; overflow-y: auto">
@@ -122,11 +122,13 @@ import 'leaflet/dist/leaflet.css';
 import { useGeolocation } from '@/composables/useGeolocation';
 import { useVehicles, type VehicleWithDistance } from '@/composables/useVehicles';
 import { useAuth } from '@/composables/useAuth';
-import { getLSIZones, createBooking } from '@/services/communautoDataService';
+import { useBackgroundAutoBook } from '@/composables/useBackgroundAutoBook';
+import { getLSIZones } from '@/services/communautoDataService';
 
 const { userLocation, locationError, locating } = useGeolocation();
 const { vehiclesWithDistance, fetchVehicles } = useVehicles(userLocation);
-const { isAuthenticated, wcfCookies } = useAuth();
+const { isAuthenticated } = useAuth();
+const bgAutoBook = useBackgroundAutoBook();
 
 const radius = ref(1000);
 const electricFilter = ref<'all' | 'electric' | 'gas'>('all');
@@ -168,87 +170,14 @@ function clearRefreshTimer() {
   }
 }
 
-// --- Auto-book ---
-const autoBookActive = ref(false);
-const autoBookError = ref<string | null>(null);
-const autoBookSuccess = ref<string | null>(null);
-let autoBookInProgress = false;
-
-function getUidFromCookies(): number | null {
-  const match = wcfCookies.value?.match(/uid=(\d+)/);
-  return match ? parseInt(match[1]) : null;
-}
-
-async function startAutoBook() {
-  autoBookError.value = null;
-  autoBookSuccess.value = null;
-  autoBookActive.value = true;
-  // Enable refresh if not already running
+// --- Auto-book (background-capable) ---
+async function handleStartAutoBook() {
+  const interval = refreshInterval.value > 0 ? refreshInterval.value : 15;
   if (refreshInterval.value === 0) {
-    setRefreshInterval(15);
+    setRefreshInterval(interval);
   }
-  // Refresh and try immediately
-  await fetchVehicles();
-  await tryAutoBook();
+  await bgAutoBook.start(userLocation.value, radius.value, interval, electricFilter.value);
 }
-
-function stopAutoBook() {
-  autoBookActive.value = false;
-}
-
-async function tryAutoBook() {
-  if (!autoBookActive.value || autoBookInProgress) return;
-  autoBookInProgress = true;
-  try {
-    await _tryAutoBookImpl();
-  } finally {
-    autoBookInProgress = false;
-  }
-}
-
-async function _tryAutoBookImpl() {
-  if (!autoBookActive.value) return;
-  const cars = vehiclesInRadius.value;
-  if (cars.length === 0) return;
-
-  const uid = getUidFromCookies();
-  if (!uid) {
-    autoBookError.value = 'uid introuvable dans les cookies';
-    autoBookActive.value = false;
-    return;
-  }
-
-  // Try each car in radius (closest first), skip if booking limit reached
-  for (const car of cars) {
-    try {
-      const res = await createBooking(uid, car.CarId);
-      const data = res.data?.d ?? res.data;
-      if (data?.Success) {
-        autoBookSuccess.value = `Réservé: #${car.CarNo} — ${car.CarBrand} ${car.CarModel} (${Math.round(car.distance)} m)`;
-        autoBookActive.value = false;
-        return;
-      }
-      // Booking limit reached on this car — try next one
-      if (data?.ErrorType === 3) {
-        autoBookError.value = `#${car.CarNo} limite atteinte, essai suivant...`;
-        continue;
-      }
-      // Other error — stop
-      autoBookError.value = data?.ErrorMessage || 'Réservation échouée';
-      return;
-    } catch (e: any) {
-      autoBookError.value = e?.message || 'Erreur réseau';
-      return;
-    }
-  }
-  // All cars in radius had booking limit reached
-  autoBookError.value = 'Limite atteinte sur tous les véhicules dans le rayon';
-}
-
-// Attempt auto-book whenever vehicle list updates
-watch(vehiclesWithDistance, () => {
-  if (autoBookActive.value) tryAutoBook();
-});
 
 // --- Map ---
 const vehiclesInRadius = computed(() =>


### PR DESCRIPTION
Extract auto-booking logic from Radar.vue into a standalone composable
(useBackgroundAutoBook) that manages its own scan interval independently
of the view lifecycle. On native Android, shows a persistent notification
while scanning and a success notification when a car is booked.

- Add notificationService wrapping @capacitor/local-notifications
- Add useBackgroundAutoBook composable with self-contained scan loop
- Add car icon drawable for notification small icon
- Update Radar.vue to use the new background-capable auto-book

https://claude.ai/code/session_01X8qDQPShmdBGbUnvtXVSjZ